### PR TITLE
bugfix: If multiple IFDs are present, seek to IFD offser before reading

### DIFF
--- a/geotiff/reader.go
+++ b/geotiff/reader.go
@@ -239,12 +239,12 @@ func readTags(r io.ReadSeeker) (Tags, head, error) {
 	// 0.
 	iFDOffset := h.iFDByteOffset
 
-	// Jump to the first IFD Byte Offset
-	if _, err := r.Seek(int64(iFDOffset), io.SeekStart); err != nil {
-		return tags, h, errors.New("error: unable to read IFD Start")
-	}
-
 	for iFDOffset != 0 {
+		// Jump to the IFD Byte Offset
+		if _, err := r.Seek(int64(iFDOffset), io.SeekStart); err != nil {
+			return tags, h, fmt.Errorf("error: unable to seek to start of IFD at %d", iFDOffset)
+		}
+
 		// Per the TIFF 6.0 Specification (p.14)
 		//
 		// The number of Directory Entries is contained in the


### PR DESCRIPTION
## Background
TIFF files contain one ore more Image File Directories (IFDs). These IFD blocks are chained so that the offset to the next IFD block is stored at the end of the current IFD block, ending when the offset is zero. The offset to the first IFD block is stored in the TIFF header.

## Bug
When reading a TIFF file with multiple IFD blocks, we presently do not seek to the next IFD at the end of the presently processed IFD block. Thus, we end up reading garbled data.

## Fix
Seek to the offset of the IFD block at the beginning of processing each IFD, not just for the first IFD.